### PR TITLE
add regex keword to all pandas.Series.str.replace

### DIFF
--- a/tests/test_1_utils.py
+++ b/tests/test_1_utils.py
@@ -17,25 +17,24 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-# Libs unittest
-import unittest
-from unittest.mock import Mock
-from unittest.mock import patch
-
+# Pour ces tests, on garde le logger pour certains tests
+# Du coup, default to critical
+import logging
+import ntpath
 
 # Utils libs
 import os
 import re
-import ntpath
+
+# Libs unittest
+import unittest
+from unittest.mock import Mock, patch
+
 import numpy as np
 import pandas as pd
-
 import words_n_fun as wnf
 from words_n_fun import utils
 
-# Pour ces tests, on garde le logger pour certains tests
-# Du coup, default to critical
-import logging
 logging.disable(logging.CRITICAL)
 logger = wnf.logger
 
@@ -528,11 +527,11 @@ class UtilsTests(unittest.TestCase):
         # Definition d'une fonction à wrapper
         def test_function_1(df):
             if type(df) != pd.DataFrame: raise TypeError('')
-            df['test1'] = df['test1'].str.replace('toto', 'titi')
+            df['test1'] = df['test1'].str.replace('toto', 'titi', regex=False)
             return df
         def test_function_2(df):
             if type(df) != pd.DataFrame: raise TypeError('')
-            df['test3'] = df['test2'].str.replace('toto', 'tata')
+            df['test3'] = df['test2'].str.replace('toto', 'tata', regex=False)
             return df
         # Vals à tester
         df_test = pd.DataFrame([['toto', 'titi', 'tata'], ['tata', 'toto', 'titi'], ['titi', 'tata', 'toto']]*50000,

--- a/words_n_fun/preprocessing/basic.py
+++ b/words_n_fun/preprocessing/basic.py
@@ -97,7 +97,7 @@ def get_true_spaces(docs: pd.Series) -> pd.Series:
         pd.Series: Modified documents
     '''
     logger.debug('Calling basic.get_true_spaces')
-    return docs.str.replace(r'\s', ' ')
+    return docs.str.replace(r'\s', ' ', regex=True)
 
 
 @utils.data_agnostic
@@ -136,7 +136,7 @@ def pe_matching(docs: pd.Series) -> pd.Series:
     logger.debug('Calling basic.pe_matching')
     # One can add more rules here
     regex = utils.get_regex_match_words(['(permis)\s+(b)'], case_insensitive=True, words_as_regex=True)
-    docs = docs.str.replace(regex, r'\2\3')
+    docs = docs.str.replace(regex, r'\2\3', regex=True)
     return docs
 
 
@@ -158,7 +158,7 @@ def remove_punct(docs: pd.Series, del_parenthesis: bool = True, replacement_char
         regex = r"[^\w\s\(\)\/]|_"
     else:
         regex = r"[^\w\s]|_"
-    return docs.str.replace(regex, replacement_char)
+    return docs.str.replace(regex, replacement_char, regex=True)
 
 
 @utils.data_agnostic
@@ -174,7 +174,7 @@ def trim_string(docs: pd.Series) -> pd.Series:
     '''
     logger.debug('Calling basic.trim_string')
     # TODO: better way ?
-    docs = docs.str.replace(r'[\t\f\v ]{2,}', ' ')
+    docs = docs.str.replace(r'[\t\f\v ]{2,}', ' ', regex=True)
     docs = remove_leading_and_ending_spaces(docs)
     return docs
 
@@ -191,8 +191,8 @@ def remove_leading_and_ending_spaces(docs: pd.Series) -> pd.Series:
         pd.Series: Modified documents
     '''
     logger.debug('Calling basic.remove_leading_and_ending_spaces')
-    docs = docs.str.replace(r'^(\s)+', '')
-    return docs.str.replace(r'(\s)+$', '')
+    docs = docs.str.replace(r'^(\s)+', '', regex=True)
+    return docs.str.replace(r'(\s)+$', '', regex=True)
 
 
 @utils.data_agnostic
@@ -208,7 +208,7 @@ def remove_numeric(docs: pd.Series, replacement_char: str = ' ') -> pd.Series:
         pd.Series: Modified documents
     '''
     logger.debug('Calling basic.remove_numeric')
-    return docs.str.replace(r'([0-9]+)', replacement_char)
+    return docs.str.replace(r'([0-9]+)', replacement_char, regex=True)
 
 
 @utils.data_agnostic
@@ -331,7 +331,7 @@ def deal_with_specific_characters(docs: pd.Series) -> pd.Series:
       pd.Series: Modified documents
     '''
     logger.debug('Calling basic.deal_with_specific_characters')
-    return docs.str.replace(r"(\s)?([',.;:])(\s)?", r' \2 ')
+    return docs.str.replace(r"(\s)?([',.;:])(\s)?", r' \2 ', regex=True)
 
 
 @utils.data_agnostic
@@ -351,9 +351,9 @@ def replace_urls(docs: pd.Series, replacement_char: str = ' ', replace_with_doma
     # based on : https://stackoverflow.com/questions/6038061/regular-expression-to-find-urls-within-a-string
     regex = r'(?i)(?<!\w|/)(((http|ftp|https):\/\/)*(www\.|ftp\.)+|((http|ftp|https):\/\/)+(www\.|ftp\.)*)([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])?'
     if not replace_with_domain:
-        return docs.str.replace(regex, replacement_char)
+        return docs.str.replace(regex, replacement_char, regex=True)
     else:
-        return docs.str.replace(regex, r' \8 ')
+        return docs.str.replace(regex, r' \8 ', regex=True)
 
 
 @utils.data_agnostic
@@ -371,7 +371,7 @@ def remove_words(docs: pd.Series, words_to_remove: List[str], case_insensitive=F
     '''
     logger.debug('Calling utils.remove_words')
     regex = utils.get_regex_match_words(words_to_remove, case_insensitive=case_insensitive)
-    return docs.str.replace(regex, '')
+    return docs.str.replace(regex, '', regex=True)
 
 
 @utils.data_agnostic

--- a/words_n_fun/preprocessing/lemmatizer.py
+++ b/words_n_fun/preprocessing/lemmatizer.py
@@ -22,12 +22,13 @@
 # - lemmatize -> Lemmatizes text
 
 
+# Get logger
+import logging
 import sys
+
 import pandas as pd
 from words_n_fun import utils
 
-# Get logger
-import logging
 logger = logging.getLogger(__name__)
 
 
@@ -76,8 +77,8 @@ def lemmatize(docs: pd.Series) -> pd.Series:
     docs = (
         pd.Series(docs)
         .str.lower()
-        .str.replace('\W', ' ')
-        .str.replace(r"([0-9]+(\.[0-9]+)?)", r" \1 ")
+        .str.replace('\W', ' ', regex=True)
+        .str.replace(r"([0-9]+(\.[0-9]+)?)", r" \1 ", regex=True)
         .str.replace('\s+', ' ', regex=True)
         .str.strip()
     )

--- a/words_n_fun/preprocessing/stopwords.py
+++ b/words_n_fun/preprocessing/stopwords.py
@@ -136,7 +136,15 @@ def remove_stopwords(docs: pd.Series, opt: str = 'all', set_to_add: Union[list, 
     if set_to_remove is None:
         set_to_remove = []
     # Check if everything is in lowercase (NaNs are replaced, letters are kept)
-    if docs.fillna('').str.replace(r"[^A-Za-z]", '').replace('', 'placeholder').str.islower().sum() != docs.shape[0]:
+    if (
+        docs
+        .fillna('')
+        .str.replace(r"[^A-Za-z]", '', regex=True)
+        .replace('', 'placeholder', regex=True)
+        .str.islower()
+        .sum() 
+        != docs.shape[0]
+    ):
         logger.warning(docs)
         logger.warning('Some characters appear to be in uppercase, stopwords are in lowercase only.')
     # Common soptwords lists
@@ -168,7 +176,7 @@ def remove_stopwords(docs: pd.Series, opt: str = 'all', set_to_add: Union[list, 
         return docs.apply(lambda x: x if isinstance(x, str) else None)
 
     regex = utils.get_regex_match_words(stopwords_list)
-    return docs.str.replace(regex, '')
+    return docs.str.replace(regex, '', regex=True)
 
 
 def stopwords_ascii() -> list:

--- a/words_n_fun/preprocessing/synonym_malefemale_replacement.py
+++ b/words_n_fun/preprocessing/synonym_malefemale_replacement.py
@@ -70,9 +70,9 @@ def remove_gender_synonyms(docs: pd.Series) -> pd.Series:
     logger.debug('Calling synonym_malefemale_replacement.getSynonyms')
 
     # Preprocessing
-    docs = docs.str.replace('(\s*)/(\s*)', '/')  # Removes whitespaces around "/"
-    docs = docs.str.replace('(\s*)\((\s*)', '(')  # Removes potential whitespaces before "("
-    docs = docs.str.replace('\)', ') ')  # Add a space after ")"
+    docs = docs.str.replace('(\s*)/(\s*)', '/', regex=True)  # Removes whitespaces around "/"
+    docs = docs.str.replace('(\s*)\((\s*)', '(', regex=True)  # Removes potential whitespaces before "("
+    docs = docs.str.replace('\)', ') ', regex=True)  # Add a space after ")"
 
     # Set match paterns
     parenthesis_pattern = r"([\w\-]+)\(([\w\-]+)\)()"  # Case :  serveur(se)


### PR DESCRIPTION
## ✒️ Context

There is numerous FutureWarning due to [pandas.Series.str.replace](https://pandas.pydata.org/docs/reference/api/pandas.Series.str.replace.html#pandas.Series.str.replace).

We can prevent it by adding regex=True to all functions using this method.

- What kind of change does this PR introduce ?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- Add regex argument to all pandas.Series.str.replace methods


## 🩺 Testing
  - [x] This change does not need new tests
  - [ ] Added/Updated unit tests

## 🔗 References

- **Issue**: Closes #7 

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
