### PR TITLE
Do check_pipeline_order once! 

### DIFF
--- a/tests/test_3_api.py
+++ b/tests/test_3_api.py
@@ -260,27 +260,27 @@ class ApiTests(unittest.TestCase):
 
     @patch('logging.Logger._log')
     def test_check_pipeline_order(self, PrintMockLog):
-        '''Testing function api.check_pipeline_order'''
+        '''Testing function api.PreProcessor.check_pipeline_order'''
         def test(docs):
             return docs
 
         # On reenable le logger
         logging.disable(logging.NOTSET)
         # Assert pas de return
-        self.assertEqual(None, api.check_pipeline_order(['test']))
+        self.assertEqual(None, api.PreProcessor.check_pipeline_order(['test']))
         # Assertions sur print
         self.assertEqual(len(PrintMockLog.mock_calls), 1)  # warning sur fonction n'existe pas
-        api.check_pipeline_order(['notnull', 'remove_non_string'])
+        api.PreProcessor.check_pipeline_order(['notnull', 'remove_non_string'])
         self.assertEqual(len(PrintMockLog.mock_calls), 1 + 1)  # warning ordre utilisation
-        api.check_pipeline_order(['notnull', 'remove_non_string', 'notnull'])
+        api.PreProcessor.check_pipeline_order(['notnull', 'remove_non_string', 'notnull'])
         self.assertEqual(len(PrintMockLog.mock_calls), 1 + 1 + 2)  # warning ordre utilisation (x2)
-        api.check_pipeline_order(['notnull', test])
+        api.PreProcessor.check_pipeline_order(['notnull', test])
         self.assertEqual(len(PrintMockLog.mock_calls), 1 + 1 + 2 + 1)  # Fonction custom
-        api.check_pipeline_order(['notnull', test, 'toto'])
+        api.PreProcessor.check_pipeline_order(['notnull', test, 'toto'])
         self.assertEqual(len(PrintMockLog.mock_calls), 1 + 1 + 2 + 1 + 2)  # Fonction custom & fonction n'existe pas
-        api.check_pipeline_order(['notnull', test, 'toto', test])
+        api.PreProcessor.check_pipeline_order(['notnull', test, 'toto', test])
         self.assertEqual(len(PrintMockLog.mock_calls), 1 + 1 + 2 + 1 + 2 + 3)  # Fonction custom (x2) & fonction n'existe pas
-        api.check_pipeline_order(['notnull', test, 'toto', 'toto'])
+        api.PreProcessor.check_pipeline_order(['notnull', test, 'toto', 'toto'])
         self.assertEqual(len(PrintMockLog.mock_calls), 1 + 1 + 2 + 1 + 2 + 3 + 3)  # Fonction custom & fonction n'existe pas (x2)
 
         # RESET DEFAULT


### PR DESCRIPTION
<!--
Before contributing :

⚠️ Any contribution that is more than a few lines of code must be stated on the corresponding issue. If there is no issue for it yet, please create it first.

This ensure that :

  1. Two people aren't working on the same thing
	2. This is something Words'n Fun's maintainers believe should be implemented/fixed
  3. Your time is well spent :)

-->

## ✒️ Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce ?

  - [ ] Bugfix
  - [x] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- Move code to PrePocessor class
- preprocess_pipeline now uses à PrePocessor
-  check_pipeline_order is done know in the __init__ so only once by object

## 🩺 Testing

- _Add bullet points summarizing your changes here_

  - [x] This change does not need new tests
  - [ ] Added/Updated unit tests

## 🔗 References

Small speed up is found with the new code

Runing 20 sentences one by one goes from 1.50 s to 1.12s in my laptop


