### PR TITLE
Optimization of regroup_data_series

### DIFF
--- a/tests/test_1_utils.py
+++ b/tests/test_1_utils.py
@@ -510,6 +510,8 @@ class UtilsTests(unittest.TestCase):
         docs_results =  pd.Series(['avant'] + ["test"] * 5000 + ['milieu'] + ["test"] * 5000 + ['après'], name='test')
         data_no_duplicates = pd.Series(['avant'] + ["ceci est un test"] + ['milieu'] + ['après'], name='test')
         data_no_duplicates_results = pd.Series(['avant'] + ["test"] + ['milieu'] + ['après'], name='test')
+        data_not_enough_duplicates = pd.Series(['avant'] + [f"ceci est un test {i}" for i in range(10)] + ['milieu']*2 + ['après'], name='test')
+        data_not_enough_duplicates_results = pd.Series(['avant'] + ["test" for i in range(10)] + ['milieu'] * 2 + ['après'], name='test')
 
 
         # Vérification du fonctionnement type
@@ -520,6 +522,11 @@ class UtilsTests(unittest.TestCase):
         pd.testing.assert_series_equal(docs_test, docs_test_copy)
         # Vérification fonctionnement quand pas de doublons
         pd.testing.assert_series_equal(utils.regroup_data_series(test_function, min_nb_data=1)(data_no_duplicates), data_no_duplicates_results)
+        # Vérification du foctionnement pas assez de doublons
+        pd.testing.assert_series_equal(utils.regroup_data_series(test_function, min_nb_data=1, max_percent_unique=0.5)(data_not_enough_duplicates), data_not_enough_duplicates_results)
+
+
+
 
 
     def test_regroup_data_df(self):

--- a/words_n_fun/preprocessing/basic.py
+++ b/words_n_fun/preprocessing/basic.py
@@ -38,19 +38,19 @@
 # - fix_text -> Fixes numerous inconsistencies within a text (via ftfy)
 
 
-import ftfy
 import logging
 import unicodedata
-import pandas as pd
+from typing import List, Union
+
+import ftfy
 import numpy as np
-from typing import Union, List
+import pandas as pd
 from nltk.stem.snowball import FrenchStemmer
 
-from words_n_fun import utils
 from words_n_fun import CustomTqdm as tqdm
-from words_n_fun.preprocessing import stopwords
-from words_n_fun.preprocessing import lemmatizer
-from words_n_fun.preprocessing import synonym_malefemale_replacement
+from words_n_fun import utils
+from words_n_fun.preprocessing import (lemmatizer, stopwords,
+                                       synonym_malefemale_replacement)
 
 tqdm.pandas()
 
@@ -314,7 +314,6 @@ def remove_numeric(docs: pd.Series, replacement_char: str = ' ') -> pd.Series:
     logger.debug('Calling basic.remove_numeric')
     return impl_remove_numeric(docs, replacement_char)
 
-@utils.regroup_data_series
 def impl_remove_stopwords(docs: pd.Series, opt: str = 'all', set_to_add: Union[list, None] = None,
                      set_to_remove: Union[list, None] = None) -> pd.Series:
     '''Removes stopwords
@@ -328,6 +327,7 @@ def impl_remove_stopwords(docs: pd.Series, opt: str = 'all', set_to_add: Union[l
     Returns:
         pd.Series: Modified documents
     '''
+    # stopwords.remove_stopwords use data_agnostic and regroup_data_series wrappers already
     return stopwords.remove_stopwords(docs, opt=opt, set_to_add=set_to_add, set_to_remove=set_to_remove)
 
 
@@ -380,7 +380,6 @@ def remove_accents(docs: pd.Series, use_tqdm: bool = False) -> pd.Series:
     '''
     return impl_remove_accents(docs, use_tqdm)
 
-@utils.regroup_data_series
 def impl_remove_gender_synonyms(docs: pd.Series) -> pd.Series:
     '''[French] Removes gendered synonyms
     # Find occurences such as "male version / female version" (eg: Coiffeur / Coiffeuse)
@@ -392,6 +391,7 @@ def impl_remove_gender_synonyms(docs: pd.Series) -> pd.Series:
     Returns:
         pd.Series: Modified documents
     '''
+    # synonym_malefemale_replacement.remove_gender_synonyms uses data_agnostic and regroup_data_series wrappers already
     return synonym_malefemale_replacement.remove_gender_synonyms(docs)
 
 

--- a/words_n_fun/preprocessing/basic.py
+++ b/words_n_fun/preprocessing/basic.py
@@ -42,6 +42,7 @@ import ftfy
 import logging
 import unicodedata
 import pandas as pd
+import numpy as np
 from typing import Union, List
 from nltk.stem.snowball import FrenchStemmer
 
@@ -211,10 +212,9 @@ def remove_numeric(docs: pd.Series, replacement_char: str = ' ') -> pd.Series:
     return docs.str.replace(r'([0-9]+)', replacement_char, regex=True)
 
 
-@utils.data_agnostic
-@utils.regroup_data_series
-def remove_stopwords(docs: pd.Series, opt: str = 'all', set_to_add: Union[list, None] = None,
-                     set_to_remove: Union[list, None] = None) -> pd.Series:
+# called function already with wrappers
+def remove_stopwords(docs: Union[str, list, np.ndarray, pd.Series, pd.DataFrame], opt: str = 'all', set_to_add: Union[list, None] = None,
+                     set_to_remove: Union[list, None] = None) -> Union[str, list, np.ndarray, pd.Series, pd.DataFrame]:
     '''Removes stopwords
 
     Args:
@@ -254,9 +254,8 @@ def remove_accents(docs: pd.Series, use_tqdm: bool = True) -> pd.Series:
         return docs.apply(lambda x: ''.join((c for c in unicodedata.normalize('NFD', x) if unicodedata.category(c) != 'Mn')) if isinstance(x, str) else None)
 
 
-@utils.data_agnostic
-@utils.regroup_data_series
-def remove_gender_synonyms(docs: pd.Series) -> pd.Series:
+# wrappers in the main function
+def remove_gender_synonyms(docs: Union[str, list, np.ndarray, pd.Series, pd.DataFrame]) -> Union[str, list, np.ndarray, pd.Series, pd.DataFrame]:
     '''[French] Removes gendered synonyms
     # Find occurences such as "male version / female version" (eg: Coiffeur / Coiffeuse)
     # By convention, the male version is kept (in accordance with the lemmatizer)
@@ -270,10 +269,8 @@ def remove_gender_synonyms(docs: pd.Series) -> pd.Series:
     logger.debug('Calling basic.remove_gender_synonyms')
     return synonym_malefemale_replacement.remove_gender_synonyms(docs)
 
-
-@utils.data_agnostic
-@utils.regroup_data_series
-def lemmatize(docs: pd.Series) -> pd.Series:
+# lemmatizer.lemmatize has already wrappers
+def lemmatize(docs: Union[str, list, np.ndarray, pd.Series, pd.DataFrame]) -> Union[str, list, np.ndarray, pd.Series, pd.DataFrame]:
     '''Lemmatizes the documents
     Appel à une API externe
 

--- a/words_n_fun/utils.py
+++ b/words_n_fun/utils.py
@@ -665,7 +665,7 @@ def regroup_data_series(function: Callable, min_nb_data:int = 1000, prefix_text:
     Kwargs:
         min_nb_data (int): Minimum number of rows within the document required to apply this wrapper (default : 1000)
         prefix_text (str): Prefix to add
-        min_percent_unique (float): value [0-1] percentage of unique values to perform reduction 
+        max_percent_unique (float): value [0-1] percentage of unique values to perform reduction 
                             for very quick functions min_percent_unique should be low to have a real speed up
     Returns:
         function: Decorated function


### PR DESCRIPTION
<!--
Before contributing :

⚠️ Any contribution that is more than a few lines of code must be stated on the corresponding issue. If there is no issue for it yet, please create it first.

This ensure that :

  1. Two people aren't working on the same thing
	2. This is something Words'n Fun's maintainers believe should be implemented/fixed
  3. Your time is well spent :)

-->

## ✒️ Context

Add more flexibility to the fuction by setting a minimum reduction on the number of unique items. This value could be optimize for each preprocessing (default maximum 90% of unique data). 


  - [ ] Bugfix
  - [x] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- Adding parameter: max_percent_unique to avoid changes when to little duplicates found
- Function optimization: avoid calling two similar costly functions: unique and drop_duplicates
- Remove wrappers when not necessary

## 🩺 Testing

- _Testing the case where there are not enough duplicates

  - [ ] This change does not need new tests
  - [x] Added/Updated unit tests

## 🔗 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
