### PR TITLE
Updated the CI and requirements to separate python versions

### DIFF
--- a/.github/workflows/wnf_build_tests_less_than_39.yaml
+++ b/.github/workflows/wnf_build_tests_less_than_39.yaml
@@ -1,4 +1,4 @@
-name: Build & Tests - Words'n Fun
+name: Build & Tests - Words'n Fun >= 3.9
 on:
   push:
     branches:
@@ -29,7 +29,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9"]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/wnf_build_tests_more_than_310.yaml
+++ b/.github/workflows/wnf_build_tests_more_than_310.yaml
@@ -1,0 +1,108 @@
+name: Build & Tests - Words'n Fun
+on:
+  push:
+    branches:
+      - 'main'
+      - 'release/v*'
+    paths-ignore:
+      - 'version.txt'
+      - '.github/workflows/**'
+      - '*.md'
+      - 'LICENSE'
+      - 'Makefile'
+  pull_request:
+    types: [opened, reopened, edit, synchronize]
+    branches:
+      - 'main'
+      - 'release/v*'
+    paths-ignore:
+      - 'version.txt'
+      - '.github/workflows/**'
+      - '*.md'
+      - 'LICENSE'
+      - 'Makefile'
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package & dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools
+          python setup.py install
+          pip install pytest
+          pip install flake8
+      - name: Lint with flake8
+        run: |
+          # Stop the build if there are Python syntax errors or undefined names
+          flake8 words_n_fun --count --select=E9,F63,F7,F82 --show-source --statistics
+          # Exit-zero treats all errors as warnings.
+          flake8 words_n_fun --count --exit-zero --max-complexity=10 --ignore=E501,W503,E266,W605,C901 --statistics
+      - name: Test WNF
+        run: pytest
+
+  build-spacy:
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package & dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools
+          pip install https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.3.0/fr_core_news_sm-3.3.0-py3-none-any.whl
+          pip install .[lemmatizer]
+          pip install pytest
+          pip install flake8
+      - name: Lint with flake8
+        run: |
+          # Stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # Exit-zero treats all errors as warnings.
+          flake8 . --count --exit-zero --max-complexity=10 --ignore=E501 --statistics
+      - name: Test WNF
+        run: pytest
+
+  build-local:
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package & dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools
+          pip install -r requirements.txt
+          python setup.py develop
+      - name: Test WNF
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 [![pypi badge](https://img.shields.io/pypi/v/words_n_fun.svg)](https://pypi.python.org/pypi/words_n_fun)
-![WNF tests](https://github.com/OSS-Pole-Emploi/words_n_fun/actions/workflows/wnf_build_tests.yaml/badge.svg)
+![WNF tests 3.9](https://github.com/OSS-Pole-Emploi/words_n_fun/actions/workflows/wnf_build_tests_less_than_39.yaml/badge.svg)
+![WNF tests 3.10](https://github.com/OSS-Pole-Emploi/words_n_fun/actions/workflows/wnf_build_tests_more_than_310.yaml/badge.svg)
 ![WNF linter](https://github.com/OSS-Pole-Emploi/words_n_fun/actions/workflows/wnf_linter.yaml/badge.svg)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-[![Generic badge](https://img.shields.io/badge/python-3.7|3.8|3.9|3.10|3.11-blue.svg)](https://shields.io/)
+[![Generic badge](https://img.shields.io/badge/python-3.7|3.8|3.9|3.10|3.11|3.12-blue.svg)](https://shields.io/)
 
 # WORDS N FUN : Semantic analysis module
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,10 +24,10 @@ black==22.8.0; python_version <= "3.9"
 black==23.3.0; python_version >= "3.10"
 isort==5.10.1; python_version <= "3.9"
 isort==5.12.0; python_version >= "3.10"
-nose==1.3.7
-nose-exclude==0.5.0
+nose==1.3.7; python_version <= "3.9"
+nose-exclude==0.5.0; python_version <= "3.9"
 coverage==6.4.4; python_version <= "3.9"
-coverage==7.3.2; python_version >= "3.10"
+pytest==7.4.2; python_version >= "3.10"
 
 # Has to be installed last / optionnal to use spacy lemmatizer
 markupsafe==2.1.3  # BUG FIX -> https://github.com/aws/aws-sam-cli/issues/3661


### PR DESCRIPTION
## ✒️ Context

_Tests with nosetests are failing starting with python version 3.10

- What kind of change does this PR introduce ?

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [x] Other, please describe: Modify the CI

## 🧱 Description of Changes

- Use pytest as tests launcher starting from 3.10. We separate the tests in two in the CI in order to delete version <3.10 in the future


## 🩺 Testing

- _Add bullet points summarizing your changes here_

  - [x] This change does not need new tests
  - [ ] Added/Updated unit tests


**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
