### PR TITLE
Remove 3.7 support. Added 3.9 dependencies and removed 3.12 from CI. 

### DIFF
--- a/.github/workflows/wnf_build_tests_less_than_39.yaml
+++ b/.github/workflows/wnf_build_tests_less_than_39.yaml
@@ -72,7 +72,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools
-          pip install https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.3.0/fr_core_news_sm-3.3.0-py3-none-any.whl
+          pip install https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.7.0/fr_core_news_sm-3.7.0-py3-none-any.whl
           pip install .[lemmatizer]
           pip install nose==1.3.7 nose-exclude==0.5.0 coverage==5.3
           pip install flake8

--- a/.github/workflows/wnf_build_tests_less_than_39.yaml
+++ b/.github/workflows/wnf_build_tests_less_than_39.yaml
@@ -29,7 +29,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
@@ -45,7 +45,7 @@ jobs:
           pip install setuptools
           python setup.py install
           pip install nose==1.3.7 nose-exclude==0.5.0 coverage==5.3
-          pip install flake8 zipp==3.15.0
+          pip install flake8
       - name: Lint with flake8
         run: |
           # Stop the build if there are Python syntax errors or undefined names
@@ -58,7 +58,7 @@ jobs:
   build-spacy:
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
@@ -75,7 +75,7 @@ jobs:
           pip install https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.3.0/fr_core_news_sm-3.3.0-py3-none-any.whl
           pip install .[lemmatizer]
           pip install nose==1.3.7 nose-exclude==0.5.0 coverage==5.3
-          pip install flake8 zipp==3.15.0
+          pip install flake8
       - name: Lint with flake8
         run: |
           # Stop the build if there are Python syntax errors or undefined names
@@ -88,7 +88,7 @@ jobs:
   build-local:
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/wnf_build_tests_less_than_39.yaml
+++ b/.github/workflows/wnf_build_tests_less_than_39.yaml
@@ -45,7 +45,7 @@ jobs:
           pip install setuptools
           python setup.py install
           pip install nose==1.3.7 nose-exclude==0.5.0 coverage==5.3
-          pip install flake8
+          pip install flake8 zipp==3.15.0
       - name: Lint with flake8
         run: |
           # Stop the build if there are Python syntax errors or undefined names
@@ -75,7 +75,7 @@ jobs:
           pip install https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.3.0/fr_core_news_sm-3.3.0-py3-none-any.whl
           pip install .[lemmatizer]
           pip install nose==1.3.7 nose-exclude==0.5.0 coverage==5.3
-          pip install flake8
+          pip install flake8 zipp==3.15.0
       - name: Lint with flake8
         run: |
           # Stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/wnf_build_tests_more_than_310.yaml
+++ b/.github/workflows/wnf_build_tests_more_than_310.yaml
@@ -58,7 +58,7 @@ jobs:
   build-spacy:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
@@ -88,7 +88,7 @@ jobs:
   build-local:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/wnf_build_tests_more_than_310.yaml
+++ b/.github/workflows/wnf_build_tests_more_than_310.yaml
@@ -72,7 +72,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools
-          pip install https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.3.0/fr_core_news_sm-3.3.0-py3-none-any.whl
+          pip install https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.7.0/fr_core_news_sm-3.7.0-py3-none-any.whl
           pip install .[lemmatizer]
           pip install pytest
           pip install flake8

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![WNF tests 3.10](https://github.com/OSS-Pole-Emploi/words_n_fun/actions/workflows/wnf_build_tests_more_than_310.yaml/badge.svg)
 ![WNF linter](https://github.com/OSS-Pole-Emploi/words_n_fun/actions/workflows/wnf_linter.yaml/badge.svg)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-[![Generic badge](https://img.shields.io/badge/python-3.7|3.8|3.9|3.10|3.11-blue.svg)](https://shields.io/)
+[![Generic badge](https://img.shields.io/badge/python-3.8|3.9|3.10|3.11-blue.svg)](https://shields.io/)
 
 # WORDS N FUN : Semantic analysis module
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,7 @@
 # Data manipulation
-numpy==1.21.6; python_version < "3.8"
-numpy==1.23.2; python_version == "3.8"
-numpy==1.23.2; python_version == "3.9"
+numpy==1.23.2; python_version < "3.10"
 numpy==1.26.0; python_version >= "3.10"
-pandas==1.3.5; python_version < "3.8"
-pandas==1.4.4; python_version == "3.8"
-pandas==1.4.4; python_version == "3.9"
+pandas==1.4.4; python_version < "3.10"
 pandas==2.1.1; python_version >= "3.10"
 
 # NLP
@@ -18,15 +14,15 @@ simplejson==3.19.2
 requests==2.31.0
 
 # Optionnals - code quality & cie
-flake8==5.0.4; python_version <= "3.9"
+flake8==5.0.4; python_version < "3.10"
 flake8==6.1.0; python_version >= "3.10"
-black==22.8.0; python_version <= "3.9"
+black==22.8.0; python_version < "3.10"
 black==23.3.0; python_version >= "3.10"
-isort==5.10.1; python_version <= "3.9"
+isort==5.10.1; python_version < "3.10"
 isort==5.12.0; python_version >= "3.10"
-nose==1.3.7; python_version <= "3.9"
-nose-exclude==0.5.0; python_version <= "3.9"
-coverage==6.4.4; python_version <= "3.9"
+nose==1.3.7; python_version < "3.10"
+nose-exclude==0.5.0; python_version < "3.10"
+coverage==6.4.4; python_version < "3.10"
 pytest==7.4.2; python_version >= "3.10"
 
 # Has to be installed last / optionnal to use spacy lemmatizer

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,8 +26,8 @@ coverage==6.4.4; python_version < "3.10"
 pytest==7.4.2; python_version >= "3.10"
 
 # Has to be installed last / optionnal to use spacy lemmatizer
-markupsafe==2.1.3  # BUG FIX -> https://github.com/aws/aws-sam-cli/issues/3661
+markupsafe==2.1.3
 Cython==3.0.3
-spacy==3.3.3
+spacy==3.7.1
 # The following line downloads a french spacy model. It can be commented if you don't have an internet access to download it, but lemmatizer features won't work.
-https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.3.0/fr_core_news_sm-3.3.0-py3-none-any.whl
+https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.7.0/fr_core_news_sm-3.7.0-py3-none-any.whl

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'requests>=2.23',
     ],
     extras_require={
-        "lemmatizer": ["spacy>=3.7.1", "markupsafe>=2.1.3", "Cython>=3.0.3", "fr-core-news-sm>=3.7.0"]
+        "lemmatizer": ["spacy>=3.7.1", "markupsafe>=2.1.3", "Cython>=3.0.3"]
     }
     # pip install words_n_fun || pip install words_n_fun[lemmatizer]
 )

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,11 @@ setup(
     install_requires=[
         'pandas>=1.3,<1.4; python_version < "3.8"',
         'pandas>=1.3,<1.5; python_version == "3.8"',
+        'pandas>=1.3,<1.5; python_version == "3.9"',
         'pandas>=1.3; python_version >= "3.10"',
         'numpy>=1.19,<1.22; python_version < "3.8"',
         'numpy>=1.19,<1.24; python_version == "3.8"',
+        'numpy>=1.19,<1.24; python_version == "3.9"',
         'numpy>=1.19; python_version >= "3.10"',
         'nltk>=3.4',
         'ftfy>=5.8',

--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,11 @@ setup(
         'nltk>=3.4',
         'ftfy>=5.8',
         'tqdm>=4.40',
-        'simplejson>=3.17',
+        'simplejson>=3.17', 
         'requests>=2.23',
     ],
     extras_require={
-        "lemmatizer": ["spacy>=3.3.3", "markupsafe>=2.0.1", "Cython>=0.29.24", "fr-core-news-sm==3.3.0"]
+        "lemmatizer": ["spacy>=3.7.1", "markupsafe>=2.1.3", "Cython>=3.0.3", "fr-core-news-sm>=3.7.0"]
     }
     # pip install words_n_fun || pip install words_n_fun[lemmatizer]
 )

--- a/setup.py
+++ b/setup.py
@@ -43,19 +43,15 @@ setup(
     description="Semantic library of the Data Services agency",
     url="https://github.com/OSS-Pole-Emploi/words_n_fun",
     platforms=['windows', 'linux'],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     package_data={
         'words_n_fun': ['configs/*.json', 'nltk_data/corpora/stopwords/french']
     },
     include_package_data=True,
     install_requires=[
-        'pandas>=1.3,<1.4; python_version < "3.8"',
-        'pandas>=1.3,<1.5; python_version == "3.8"',
-        'pandas>=1.3,<1.5; python_version == "3.9"',
+        'pandas>=1.3,<1.5; python_version < "3.10"',
         'pandas>=1.3; python_version >= "3.10"',
-        'numpy>=1.19,<1.22; python_version < "3.8"',
-        'numpy>=1.19,<1.24; python_version == "3.8"',
-        'numpy>=1.19,<1.24; python_version == "3.9"',
+        'numpy>=1.19,<1.24; python_version < "3.10"',
         'numpy>=1.19; python_version >= "3.10"',
         'nltk>=3.4',
         'ftfy>=5.8',


### PR DESCRIPTION
## ✒️ Context

The tests are not passing due to silly mistakes and the spacy model being in setup.py

- What kind of change does this PR introduce ?

  - [x] Bugfix
  - [ ] Feature
  - [ ] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

Properly deleted python 3.12 from CI
Added dependencies for 3.9 in setup.py
Removed 3.7 support
Removed the model from setup.py


## 🩺 Testing

- _Add bullet points summarizing your changes here_

  - [x] This change does not need new tests
  - [ ] Added/Updated unit tests


By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
