### PR TITLE
split_sentences: fix parenthesis, more rules, tests

### DIFF
--- a/tests/test_8_split_sentences.py
+++ b/tests/test_8_split_sentences.py
@@ -43,10 +43,106 @@ class SplitSentencesTests(unittest.TestCase):
         dname = os.path.dirname(abspath)
         os.chdir(dname)
 
+    def test_re_multiline(self):
+        """ Test multiline regex"""
+        text = "Toto \n Tata \n\n Et fin"
+        result = split_sentences.re_multiline.split(text)
+        expected = ['Toto', ' Tata', ' Et fin']
+        self.assertEquals(result, expected)
+
+    def test_re_lastspace(self):
+        """ Test last space regex regex"""
+        text = "Toto   \n Tata \n\n Et fin  \t  "
+        result = split_sentences.re_lastspace.sub('', text)
+        expected = 'Toto   \n Tata \n\n Et fin'
+        self.assertEquals(result, expected)
+
+    def test_parenthesis_to_key(self):
+        """ Test last space regex regex"""
+        text = "(Tata (titi) tutu)  Mais pas de )( sans rien"
+        result, keys = split_sentences.parenthesis_to_key(text)        
+
+        expected = "UID_PE_PARENTHESES_1  Mais pas de )( sans rien"
+        expected_keys = [
+            ("UID_PE_PARENTHESES_0","(titi)"),
+            ("UID_PE_PARENTHESES_1","(Tata UID_PE_PARENTHESES_0 tutu)")
+            ]
+        self.assertEquals(expected, result)
+        self.assertEquals(expected_keys, keys)
+
+    def test_key_to_parenthesis(self):
+        """ Test last space regex regex"""
+
+        text = ["UID_PE_PARENTHESES_1  Mais","pas de )( sans rien de UID_PE_PARENTHESES_2"]
+        keys = [
+            ("UID_PE_PARENTHESES_0","(titi)"),
+            ("UID_PE_PARENTHESES_1","(Tata UID_PE_PARENTHESES_0 tutu)"),
+            ("UID_PE_PARENTHESES_2","(Tarari)")
+            ]
+
+        result = split_sentences.key_to_parenthesis(text, keys)        
+
+        expected = ["(Tata (titi) tutu)  Mais","pas de )( sans rien de (Tarari)"]
+        self.assertEquals(expected, result)
+
+    def test_extra_split(self):
+        ''' tests cases of script'''
+        # Same splits
+        sentences = "Normal sentence! Do split. And again."
+        expected = ["Normal sentence! ","Do split. ","And again."]
+        self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
+        self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
+
+        sentences = "And M. Smith is doing great"
+        expected = ["And M. Smith is doing great"]
+        self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
+        self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
+
+
+        # Better v2
+        sentences = "The company A.N.D. is doing great"
+        expected = ["The company A.N.D. ","is doing great"]
+        self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
+        expected = ["The company A.N.D. is doing great"]
+        self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
+
+        sentences = "The company A. N. D. is doing great"
+        expected = ["The company A. ","N. ","D. ","is doing great"]
+        self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
+        expected = ["The company A. N. D. is doing great"]
+        self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
+
+        sentences = "M. Smith is doing great"
+        expected = ["M. ","Smith is doing great"]
+        self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
+        expected = ["M. Smith is doing great"]
+        self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
+
+        sentences = "And Mme. Smith is doing great"
+        expected = ["And Mme. ","Smith is doing great"]
+        self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
+        expected = ["And Mme. Smith is doing great"]
+        self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
+
+        sentences = "Dr. Smith is doing great"
+        expected = ["Dr. ","Smith is doing great"]
+        self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
+        expected = ["Dr. Smith is doing great"]
+        self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
+
+        # Bettter v1 
+        sentences = "Give me an A. Give me a B."
+        expected = ["Give me an A. ","Give me a B."]
+        self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
+        expected = ["Give me an A. Give me a B."]
+        self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
+
+
 
     def test_split_sentences_0(self):
         '''On check juste les formats d'entrées de split_sentences'''
         self.assertEqual(split_sentences.split_sentences('test'), ['test'])
+        self.assertEqual(split_sentences.split_sentences('test', 2), ['test'])
 
 
     def test_split_sentences_1(self):
@@ -67,6 +163,7 @@ class SplitSentencesTests(unittest.TestCase):
                  '- Qualité relationnelles et rédactionnelles / Organisation / Rigueur',
                  '- Permis B et véhicule indispensables']
         self.assertEqual(split_sentences.split_sentences(text), result)
+        self.assertEqual(split_sentences.split_sentences(text,2), result)
 
 
     def test_split_sentences_2(self):
@@ -81,6 +178,7 @@ class SplitSentencesTests(unittest.TestCase):
                   "Présent depuis 2007 en Loire-Atlantique nous vous proposons de rejoindre notre équipe dédiée 100% à l'audition (nous disposons de l'agrément Lyric).",
                   'Vous aurez la garantie de travailler dans les meilleures conditions possibles avec comme seul objectif la satisfaction du patient.']
         self.assertEqual(split_sentences.split_sentences(text), result)
+        self.assertEqual(split_sentences.split_sentences(text,2), result)
 
 
     def test_split_sentences_3(self):
@@ -101,6 +199,7 @@ class SplitSentencesTests(unittest.TestCase):
                   'Etre véhiculé(e) est un plus. ',
                   'Prise de poste courant avril, après processus de recrutement et formation.']
         self.assertEqual(split_sentences.split_sentences(text), result)
+        self.assertEqual(split_sentences.split_sentences(text,2), result)
 
 
     def test_split_sentences_4(self):
@@ -116,6 +215,7 @@ class SplitSentencesTests(unittest.TestCase):
                   'Malgré la crise sanitaire du COVID19, le process de recrutement est maintenu dans le respect des règles sanitaires en vigueur. ',
                   "N'hésitez pas à postuler."]
         self.assertEqual(split_sentences.split_sentences(text), result)
+        self.assertEqual(split_sentences.split_sentences(text,2), result)
 
 
     def test_split_sentences_5(self):
@@ -131,6 +231,7 @@ class SplitSentencesTests(unittest.TestCase):
                   '** Aucun logement possible sur place **',
                   "L'employeur déclare mettre en œuvre les mesures sanitaires pour préserver la santé et la sécurité de ses salariés."]
         self.assertEqual(split_sentences.split_sentences(text), result)
+        self.assertEqual(split_sentences.split_sentences(text,2), result)
 
 
     def test_split_sentences_6(self):
@@ -151,6 +252,7 @@ class SplitSentencesTests(unittest.TestCase):
                   'Targett Interim',
                   's.vaillant@outlook.fr']
         self.assertEqual(split_sentences.split_sentences(text), result)
+        self.assertEqual(split_sentences.split_sentences(text,2), result)
 
 
     def test_split_sentences_7(self):
@@ -162,6 +264,7 @@ class SplitSentencesTests(unittest.TestCase):
                   'Organisation: des activités en fonction des besoins des enfants et de la collectivité, du poste de travail, gestion des stocks et des matériaux',
                   "Vous êtes titulaire du diplôme d'état de puériculture."]
         self.assertEqual(split_sentences.split_sentences(text), result)
+        self.assertEqual(split_sentences.split_sentences(text,2), result)
 
 
     def test_split_sentences_8(self):
@@ -171,6 +274,7 @@ class SplitSentencesTests(unittest.TestCase):
                   'Poste (pour la durée de la crise) en remplacement (pour la durée de la crise) sanitaire.',
                   "missions recentrées prioritairement autour de l'entretien des locaux (avec renforcement des procédures d'hygiène en lien avec la situation sanitaire! , service des repas, vaisselle... )."]
         self.assertEqual(split_sentences.split_sentences(text), result)
+        self.assertEqual(split_sentences.split_sentences(text,2), result)
 
 
     def test_split_sentences_9(self):
@@ -189,6 +293,7 @@ class SplitSentencesTests(unittest.TestCase):
                   "Passionné(e) par le cuir et s'inscrivant dans une démarche Qualité et d'Amélioration Continue permanente et individuelle, vous souhaitez participer à un véritable projet d'entreprise.",
                   'Horaires : de 15h00 à 23h00 du Lundi au Jeudi et de 11h00 à 17h00 le Vendredi.']
         self.assertEqual(split_sentences.split_sentences(text), result)
+        self.assertEqual(split_sentences.split_sentences(text,2), result)
 
 
     def test_split_sentences_10(self):
@@ -225,6 +330,21 @@ class SplitSentencesTests(unittest.TestCase):
                   "-  Possibilité d'intégration rapide, de formation et d'évolution,",
                   "-  Bénéficiez d'aides et de services dédiés (mutuelle, logement, garde enfant, déplacement )."]
         self.assertEqual(split_sentences.split_sentences(text), result)
+        self.assertEqual(split_sentences.split_sentences(text,2), result)
+
+    def test_split_acronyms(self):
+        text = "Au sein d'une usine de fabrication de A. T. R. S.\nM. Machin sera votre superviseur"
+        result = ["Au sein d'une usine de fabrication de A. ","T. ","R. ","S.","M. ","Machin sera votre superviseur"]
+        self.assertEqual(split_sentences.split_sentences(text), result) # too many splits
+        result = ["Au sein d'une usine de fabrication de A. T. R. S.","M. Machin sera votre superviseur"]
+        self.assertEqual(split_sentences.split_sentences(text,2), result)
+
+    def test_split_extra_parenthesis(self):
+        text = " Je suis bon en langues (Anglais (Lu, Parlé). Espagnol (Parlé)) et en sports"
+        result= [" Je suis bon en langues (Anglais (Lu, Parlé). ","Espagnol (Parlé)) et en sports"]
+        self.assertEqual(split_sentences.split_sentences(text), [text]) # error in parenthesis split
+        result= [" Je suis bon en langues (Anglais (Lu, Parlé). Espagnol (Parlé)) et en sports"]
+        self.assertEqual(split_sentences.split_sentences(text,2), result) # v2 = no split, '.' in parenthesis
 
 
     def test_split_sentences_df(self):
@@ -243,6 +363,8 @@ class SplitSentencesTests(unittest.TestCase):
 
         # split_sentences_df(df, col)
         df_processed = split_sentences.split_sentences_df(df, 'OFF_DESCRIPTION')
+        pd.testing.assert_frame_equal(df_processed, df_result)
+        df_processed = split_sentences.split_sentences_df(df, 'OFF_DESCRIPTION', version=2)
         pd.testing.assert_frame_equal(df_processed, df_result)
         pd.testing.assert_frame_equal(df, df2)  # On check si pas de modif. sur df original
 

--- a/tests/test_8_split_sentences.py
+++ b/tests/test_8_split_sentences.py
@@ -28,15 +28,15 @@ from words_n_fun.preprocessing import split_sentences
 
 # Disable logging
 import logging
+
 logging.disable(logging.CRITICAL)
 
 
 class SplitSentencesTests(unittest.TestCase):
-    '''Main class to test functions in split_sentences'''
-
+    """Main class to test functions in split_sentences"""
 
     def setUp(self):
-        '''SetUp fonction'''
+        """SetUp fonction"""
         # On se place dans le bon répertoire
         # Change directory to script directory
         abspath = os.path.abspath(__file__)
@@ -44,52 +44,55 @@ class SplitSentencesTests(unittest.TestCase):
         os.chdir(dname)
 
     def test_re_multiline(self):
-        """ Test multiline regex"""
+        """Test multiline regex"""
         text = "Toto \n Tata \n\n Et fin"
         result = split_sentences.re_multiline.split(text)
-        expected = ['Toto', ' Tata', ' Et fin']
+        expected = ["Toto", " Tata", " Et fin"]
         self.assertEquals(result, expected)
 
     def test_re_lastspace(self):
-        """ Test last space regex regex"""
+        """Test last space regex regex"""
         text = "Toto   \n Tata \n\n Et fin  \t  "
-        result = split_sentences.re_lastspace.sub('', text)
-        expected = 'Toto   \n Tata \n\n Et fin'
+        result = split_sentences.re_lastspace.sub("", text)
+        expected = "Toto   \n Tata \n\n Et fin"
         self.assertEquals(result, expected)
 
     def test_parenthesis_to_key(self):
-        """ Test last space regex regex"""
+        """Test last space regex regex"""
         text = "(Tata (titi) tutu)  Mais pas de )( sans rien"
-        result, keys = split_sentences.parenthesis_to_key(text)        
+        result, keys = split_sentences.parenthesis_to_key(text)
 
         expected = "UID_PE_PARENTHESES_1  Mais pas de )( sans rien"
         expected_keys = [
-            ("UID_PE_PARENTHESES_0","(titi)"),
-            ("UID_PE_PARENTHESES_1","(Tata UID_PE_PARENTHESES_0 tutu)")
-            ]
+            ("UID_PE_PARENTHESES_0", "(titi)"),
+            ("UID_PE_PARENTHESES_1", "(Tata UID_PE_PARENTHESES_0 tutu)"),
+        ]
         self.assertEquals(expected, result)
         self.assertEquals(expected_keys, keys)
 
     def test_key_to_parenthesis(self):
-        """ Test last space regex regex"""
+        """Test last space regex regex"""
 
-        text = ["UID_PE_PARENTHESES_1  Mais","pas de )( sans rien de UID_PE_PARENTHESES_2"]
+        text = [
+            "UID_PE_PARENTHESES_1  Mais",
+            "pas de )( sans rien de UID_PE_PARENTHESES_2",
+        ]
         keys = [
-            ("UID_PE_PARENTHESES_0","(titi)"),
-            ("UID_PE_PARENTHESES_1","(Tata UID_PE_PARENTHESES_0 tutu)"),
-            ("UID_PE_PARENTHESES_2","(Tarari)")
-            ]
+            ("UID_PE_PARENTHESES_0", "(titi)"),
+            ("UID_PE_PARENTHESES_1", "(Tata UID_PE_PARENTHESES_0 tutu)"),
+            ("UID_PE_PARENTHESES_2", "(Tarari)"),
+        ]
 
-        result = split_sentences.key_to_parenthesis(text, keys)        
+        result = split_sentences.key_to_parenthesis(text, keys)
 
-        expected = ["(Tata (titi) tutu)  Mais","pas de )( sans rien de (Tarari)"]
+        expected = ["(Tata (titi) tutu)  Mais", "pas de )( sans rien de (Tarari)"]
         self.assertEquals(expected, result)
 
     def test_extra_split(self):
-        ''' tests cases of script'''
+        """tests cases of script"""
         # Same splits
         sentences = "Normal sentence! Do split. And again."
-        expected = ["Normal sentence! ","Do split. ","And again."]
+        expected = ["Normal sentence! ", "Do split. ", "And again."]
         self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
         self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
 
@@ -98,279 +101,315 @@ class SplitSentencesTests(unittest.TestCase):
         self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
         self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
 
-
         # Better v2
         sentences = "The company A.N.D. is doing great"
-        expected = ["The company A.N.D. ","is doing great"]
+        expected = ["The company A.N.D. ", "is doing great"]
         self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
         expected = ["The company A.N.D. is doing great"]
         self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
 
         sentences = "The company A. N. D. is doing great"
-        expected = ["The company A. ","N. ","D. ","is doing great"]
+        expected = ["The company A. ", "N. ", "D. ", "is doing great"]
         self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
         expected = ["The company A. N. D. is doing great"]
         self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
 
         sentences = "M. Smith is doing great"
-        expected = ["M. ","Smith is doing great"]
+        expected = ["M. ", "Smith is doing great"]
         self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
         expected = ["M. Smith is doing great"]
         self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
 
         sentences = "And Mme. Smith is doing great"
-        expected = ["And Mme. ","Smith is doing great"]
+        expected = ["And Mme. ", "Smith is doing great"]
         self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
         expected = ["And Mme. Smith is doing great"]
         self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
 
         sentences = "Dr. Smith is doing great"
-        expected = ["Dr. ","Smith is doing great"]
+        expected = ["Dr. ", "Smith is doing great"]
         self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
         expected = ["Dr. Smith is doing great"]
         self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
 
-        # Bettter v1 
+        # Bettter v1
         sentences = "Give me an A. Give me a B."
-        expected = ["Give me an A. ","Give me a B."]
+        expected = ["Give me an A. ", "Give me a B."]
         self.assertEqual(split_sentences.re_specialsplit_v1.split(sentences), expected)
         expected = ["Give me an A. Give me a B."]
         self.assertEqual(split_sentences.re_specialsplit_v2.split(sentences), expected)
 
-
-
     def test_split_sentences_0(self):
-        '''On check juste les formats d'entrées de split_sentences'''
-        self.assertEqual(split_sentences.split_sentences('test'), ['test'])
-        self.assertEqual(split_sentences.split_sentences('test', 2), ['test'])
-
+        """On check juste les formats d'entrées de split_sentences"""
+        self.assertEqual(split_sentences.split_sentences("test"), ["test"])
+        self.assertEqual(split_sentences.split_sentences("test", 2), ["test"])
 
     def test_split_sentences_1(self):
         # Vals à tester
         text = "Sous la Direction de M. Untel, vous prenez en charge l'animation des formations en habilitations électriques pour personnel électricien.\nVous participez également à l'adaptation des formations aux évolutions réglementaires et de marché.\nFormations sur sites : déplacements fréquents à prévoir.\n\nDétail de l'Offre :\n- Type de contrat : CDD à la mission ou contrat de prestation\n- Lieu : Région Midi-Pyrénées \n- Rémunération : Selon statut\n\nProfil :\n- BTS, DUT en génie Electrique ou Electrotechnique \n- Expérience avérée dans le domaine de l'électricité\n- Vous avez une expérience de 2 ans minimum dans le domaine de la formation\n- Vous aimez transmettre et veillez à la satisfaction client.\n- Qualité relationnelles et rédactionnelles / Organisation / Rigueur\n- Permis B et véhicule indispensables"
-        result = ["Sous la Direction de M. Untel, vous prenez en charge l'animation des formations en habilitations électriques pour personnel électricien.",
-                 "Vous participez également à l'adaptation des formations aux évolutions réglementaires et de marché.",
-                 'Formations sur sites : déplacements fréquents à prévoir.',
-                 "Détail de l'Offre :",
-                 '- Type de contrat : CDD à la mission ou contrat de prestation',
-                 '- Lieu : Région Midi-Pyrénées',
-                 '- Rémunération : Selon statut',
-                 'Profil :',
-                 '- BTS, DUT en génie Electrique ou Electrotechnique',
-                 "- Expérience avérée dans le domaine de l'électricité",
-                 '- Vous avez une expérience de 2 ans minimum dans le domaine de la formation',
-                 '- Vous aimez transmettre et veillez à la satisfaction client.',
-                 '- Qualité relationnelles et rédactionnelles / Organisation / Rigueur',
-                 '- Permis B et véhicule indispensables']
+        result = [
+            "Sous la Direction de M. Untel, vous prenez en charge l'animation des formations en habilitations électriques pour personnel électricien.",
+            "Vous participez également à l'adaptation des formations aux évolutions réglementaires et de marché.",
+            "Formations sur sites : déplacements fréquents à prévoir.",
+            "Détail de l'Offre :",
+            "- Type de contrat : CDD à la mission ou contrat de prestation",
+            "- Lieu : Région Midi-Pyrénées",
+            "- Rémunération : Selon statut",
+            "Profil :",
+            "- BTS, DUT en génie Electrique ou Electrotechnique",
+            "- Expérience avérée dans le domaine de l'électricité",
+            "- Vous avez une expérience de 2 ans minimum dans le domaine de la formation",
+            "- Vous aimez transmettre et veillez à la satisfaction client.",
+            "- Qualité relationnelles et rédactionnelles / Organisation / Rigueur",
+            "- Permis B et véhicule indispensables",
+        ]
         self.assertEqual(split_sentences.split_sentences(text), result)
-        self.assertEqual(split_sentences.split_sentences(text,2), result)
-
+        self.assertEqual(split_sentences.split_sentences(text, 2), result)
+        # test wrong version
+        self.assertRaises(ValueError, split_sentences.split_sentences, text, 3)
 
     def test_split_sentences_2(self):
         # Vals à tester
         text = "Malgré la crise sanitaire du COVID19, l'offre d'emploi est maintenue. Le recrutement peut être reporté à une date ultérieure. N'hésitez pas à postuler. \n\nNous recherchons un(e)  audioprothésiste confirmé(e) ou jeune diplômé(e) pour compléter notre équipe. Vous travaillerez  au sein de nos laboratoires de Nort sur Erdre, Savenay et St Nazaire (planning à définir selon l'activité).\n\nTemps partiel possible.\n \nPrésent depuis 2007 en Loire-Atlantique nous vous proposons de rejoindre notre équipe dédiée 100% à l'audition (nous disposons de l'agrément Lyric).\n\nVous aurez la garantie de travailler dans les meilleures conditions possibles avec comme seul objectif la satisfaction du patient.\n\n"
-        result = ["Malgré la crise sanitaire du COVID19, l'offre d'emploi est maintenue. ",
-                  'Le recrutement peut être reporté à une date ultérieure. ',
-                  "N'hésitez pas à postuler.",
-                  'Nous recherchons un(e)  audioprothésiste confirmé(e) ou jeune diplômé(e) pour compléter notre équipe. ',
-                  "Vous travaillerez  au sein de nos laboratoires de Nort sur Erdre, Savenay et St Nazaire (planning à définir selon l'activité).",
-                  'Temps partiel possible.',
-                  "Présent depuis 2007 en Loire-Atlantique nous vous proposons de rejoindre notre équipe dédiée 100% à l'audition (nous disposons de l'agrément Lyric).",
-                  'Vous aurez la garantie de travailler dans les meilleures conditions possibles avec comme seul objectif la satisfaction du patient.']
+        result = [
+            "Malgré la crise sanitaire du COVID19, l'offre d'emploi est maintenue. ",
+            "Le recrutement peut être reporté à une date ultérieure. ",
+            "N'hésitez pas à postuler.",
+            "Nous recherchons un(e)  audioprothésiste confirmé(e) ou jeune diplômé(e) pour compléter notre équipe. ",
+            "Vous travaillerez  au sein de nos laboratoires de Nort sur Erdre, Savenay et St Nazaire (planning à définir selon l'activité).",
+            "Temps partiel possible.",
+            "Présent depuis 2007 en Loire-Atlantique nous vous proposons de rejoindre notre équipe dédiée 100% à l'audition (nous disposons de l'agrément Lyric).",
+            "Vous aurez la garantie de travailler dans les meilleures conditions possibles avec comme seul objectif la satisfaction du patient.",
+        ]
         self.assertEqual(split_sentences.split_sentences(text), result)
-        self.assertEqual(split_sentences.split_sentences(text,2), result)
-
+        self.assertEqual(split_sentences.split_sentences(text, 2), result)
 
     def test_split_sentences_3(self):
         # Vals à tester
         text = "CC3F. Vos missions : en capacité, en cuisine, de préparer les ingrédients des burritos que nous servons, accueillir les clients, être à l'ouverture ou à la fermeture du restaurant. Vous encaisserez les clients. Vous serez également en capacité de suivre les stocks et de réceptionner les marchandises. Vous respecterez les procédures de caisse, de coffre et de dépôts et alerterez la hiérarchie si anomalie. Vous respecterez les règles d'hygiène et de sécurité. Vous contribuerez à la gestion des déchets. Vous superviserez l'équipe et formerez les nouveaux employés. vous suivrez une formation adaptée à nos besoins, avant embauche. Horaires du restaurant, i.e. 8h30/23h (voire plus), du lundi au samedi. Vous travaillerez avec des horaires en coupure. Contrats entre 15h et 24h/s. Etre véhiculé(e) est un plus. Prise de poste courant avril, après processus de recrutement et formation."
-        result = ['CC3F. ',
-                  "Vos missions : en capacité, en cuisine, de préparer les ingrédients des burritos que nous servons, accueillir les clients, être à l'ouverture ou à la fermeture du restaurant. ",
-                  'Vous encaisserez les clients. ',
-                  'Vous serez également en capacité de suivre les stocks et de réceptionner les marchandises. ',
-                  'Vous respecterez les procédures de caisse, de coffre et de dépôts et alerterez la hiérarchie si anomalie. ',
-                  "Vous respecterez les règles d'hygiène et de sécurité. ",
-                  'Vous contribuerez à la gestion des déchets. ',
-                  "Vous superviserez l'équipe et formerez les nouveaux employés. ",
-                  'vous suivrez une formation adaptée à nos besoins, avant embauche. ',
-                  'Horaires du restaurant, i.e. 8h30/23h (voire plus), du lundi au samedi. ',
-                  'Vous travaillerez avec des horaires en coupure. ',
-                  'Contrats entre 15h et 24h/s. ',
-                  'Etre véhiculé(e) est un plus. ',
-                  'Prise de poste courant avril, après processus de recrutement et formation.']
+        result = [
+            "CC3F. ",
+            "Vos missions : en capacité, en cuisine, de préparer les ingrédients des burritos que nous servons, accueillir les clients, être à l'ouverture ou à la fermeture du restaurant. ",
+            "Vous encaisserez les clients. ",
+            "Vous serez également en capacité de suivre les stocks et de réceptionner les marchandises. ",
+            "Vous respecterez les procédures de caisse, de coffre et de dépôts et alerterez la hiérarchie si anomalie. ",
+            "Vous respecterez les règles d'hygiène et de sécurité. ",
+            "Vous contribuerez à la gestion des déchets. ",
+            "Vous superviserez l'équipe et formerez les nouveaux employés. ",
+            "vous suivrez une formation adaptée à nos besoins, avant embauche. ",
+            "Horaires du restaurant, i.e. 8h30/23h (voire plus), du lundi au samedi. ",
+            "Vous travaillerez avec des horaires en coupure. ",
+            "Contrats entre 15h et 24h/s. ",
+            "Etre véhiculé(e) est un plus. ",
+            "Prise de poste courant avril, après processus de recrutement et formation.",
+        ]
         self.assertEqual(split_sentences.split_sentences(text), result)
-        self.assertEqual(split_sentences.split_sentences(text,2), result)
-
+        self.assertEqual(split_sentences.split_sentences(text, 2), result)
 
     def test_split_sentences_4(self):
         # Vals à tester
         text = "Laurent, le Responsable et son équipe de 6 personnes vous attendent pour participer au bon fonctionnement des réseaux d'alimentation en eau potable et assainissement sur le périmètre de La Roche sur Yon. \n\nVous réalisez l'entretien et la maintenance des réseaux d'eau et des équipements hydrauliques.\nVous effectuez les travaux de terrassement pour la pose et le renouvellement des canalisations sur les chantiers\nVous contribuez à la réparation des fuites d'eau \nVous réalisez la maintenance des équipements sur le réseau : Poteaux incendie, châteaux d'eau, purges, ventouse, stabilisateurs de pression, débitmètres....\n\nLe respect des règles de sécurité est fondamental sur le poste.\n\nL'astreinte vous amènera à intervenir en cas d'urgence pour garantir la continuité du service (permis B + véhicule de service).\n\nMalgré la crise sanitaire du COVID19, le process de recrutement est maintenu dans le respect des règles sanitaires en vigueur. N'hésitez pas à postuler."
-        result = ["Laurent, le Responsable et son équipe de 6 personnes vous attendent pour participer au bon fonctionnement des réseaux d'alimentation en eau potable et assainissement sur le périmètre de La Roche sur Yon.",
-                  "Vous réalisez l'entretien et la maintenance des réseaux d'eau et des équipements hydrauliques.",
-                  'Vous effectuez les travaux de terrassement pour la pose et le renouvellement des canalisations sur les chantiers',
-                  "Vous contribuez à la réparation des fuites d'eau",
-                  "Vous réalisez la maintenance des équipements sur le réseau : Poteaux incendie, châteaux d'eau, purges, ventouse, stabilisateurs de pression, débitmètres....",
-                  'Le respect des règles de sécurité est fondamental sur le poste.',
-                  "L'astreinte vous amènera à intervenir en cas d'urgence pour garantir la continuité du service (permis B + véhicule de service).",
-                  'Malgré la crise sanitaire du COVID19, le process de recrutement est maintenu dans le respect des règles sanitaires en vigueur. ',
-                  "N'hésitez pas à postuler."]
+        result = [
+            "Laurent, le Responsable et son équipe de 6 personnes vous attendent pour participer au bon fonctionnement des réseaux d'alimentation en eau potable et assainissement sur le périmètre de La Roche sur Yon.",
+            "Vous réalisez l'entretien et la maintenance des réseaux d'eau et des équipements hydrauliques.",
+            "Vous effectuez les travaux de terrassement pour la pose et le renouvellement des canalisations sur les chantiers",
+            "Vous contribuez à la réparation des fuites d'eau",
+            "Vous réalisez la maintenance des équipements sur le réseau : Poteaux incendie, châteaux d'eau, purges, ventouse, stabilisateurs de pression, débitmètres....",
+            "Le respect des règles de sécurité est fondamental sur le poste.",
+            "L'astreinte vous amènera à intervenir en cas d'urgence pour garantir la continuité du service (permis B + véhicule de service).",
+            "Malgré la crise sanitaire du COVID19, le process de recrutement est maintenu dans le respect des règles sanitaires en vigueur. ",
+            "N'hésitez pas à postuler.",
+        ]
         self.assertEqual(split_sentences.split_sentences(text), result)
-        self.assertEqual(split_sentences.split_sentences(text,2), result)
-
+        self.assertEqual(split_sentences.split_sentences(text, 2), result)
 
     def test_split_sentences_5(self):
         # Vals à tester
         text = "Vous effectuez les travaux en vert de la vigne :  \nÉbourgeonnage\nEpillonage\nRelevage\nBinage\nContrat saisonnier, prise de poste fin avril ou début mai selon météo. Vous avez impérativement votre moyen de locomotion pour accéder seul aux parcelles de l'exploitation. ** Aucun logement possible sur place ** \nL'employeur déclare mettre en œuvre les mesures sanitaires pour préserver la santé et la sécurité de ses salariés.\n"
-        result = ['Vous effectuez les travaux en vert de la vigne :',
-                  'Ébourgeonnage',
-                  'Epillonage',
-                  'Relevage',
-                  'Binage',
-                  'Contrat saisonnier, prise de poste fin avril ou début mai selon météo. ',
-                  "Vous avez impérativement votre moyen de locomotion pour accéder seul aux parcelles de l'exploitation. ",
-                  '** Aucun logement possible sur place **',
-                  "L'employeur déclare mettre en œuvre les mesures sanitaires pour préserver la santé et la sécurité de ses salariés."]
+        result = [
+            "Vous effectuez les travaux en vert de la vigne :",
+            "Ébourgeonnage",
+            "Epillonage",
+            "Relevage",
+            "Binage",
+            "Contrat saisonnier, prise de poste fin avril ou début mai selon météo. ",
+            "Vous avez impérativement votre moyen de locomotion pour accéder seul aux parcelles de l'exploitation. ",
+            "** Aucun logement possible sur place **",
+            "L'employeur déclare mettre en œuvre les mesures sanitaires pour préserver la santé et la sécurité de ses salariés.",
+        ]
         self.assertEqual(split_sentences.split_sentences(text), result)
-        self.assertEqual(split_sentences.split_sentences(text,2), result)
-
+        self.assertEqual(split_sentences.split_sentences(text, 2), result)
 
     def test_split_sentences_6(self):
         # Vals à tester
         text = "L'agence d'emploi (CDI, intérim et formation) Targett Interim (62970) recherche pour un de ses clients un « Poseur d'enseignes lumineuses » H/F \n\nAu sein d'une entreprise spécialisée dans la réalisation et la pose d'enseignes lumineuses, vous aurez pour mission: \n- Pose d'enseignes ou d'adhésifs sur façade de bâtiment et magasin.\n- Travail en équipe de 2 avec un chef d'équipe\n- Utilisation de petits outillages\n- Poste parfois en hauteur\n- Contact clientèle\n- Respect des règles de sécurité\n\nPoste à pourvoir dès que possible pour une période de 6 mois renouvelable. \n\nVous souhaitez intégrer une agence d'intérim qui est à votre écoute, réactive dès que vous avez besoin d'un document administratif, qui fait tout pour vous trouver le poste de vos rêves ? Vous en avez marre d'être considéré comme un numéro et vous voulez avoir un sentiment d'appartenance ? Alors rejoignez-nous ! \nTargett Interim \ns.vaillant@outlook.fr"
-        result = ["L'agence d'emploi (CDI, intérim et formation) Targett Interim (62970) recherche pour un de ses clients un « Poseur d'enseignes lumineuses » H/F",
-                  "Au sein d'une entreprise spécialisée dans la réalisation et la pose d'enseignes lumineuses, vous aurez pour mission:",
-                  "- Pose d'enseignes ou d'adhésifs sur façade de bâtiment et magasin.",
-                  "- Travail en équipe de 2 avec un chef d'équipe",
-                  '- Utilisation de petits outillages',
-                  '- Poste parfois en hauteur',
-                  '- Contact clientèle',
-                  '- Respect des règles de sécurité',
-                  'Poste à pourvoir dès que possible pour une période de 6 mois renouvelable.',
-                  "Vous souhaitez intégrer une agence d'intérim qui est à votre écoute, réactive dès que vous avez besoin d'un document administratif, qui fait tout pour vous trouver le poste de vos rêves ? ",
-                  "Vous en avez marre d'être considéré comme un numéro et vous voulez avoir un sentiment d'appartenance ? ",
-                  'Alors rejoignez-nous !',
-                  'Targett Interim',
-                  's.vaillant@outlook.fr']
+        result = [
+            "L'agence d'emploi (CDI, intérim et formation) Targett Interim (62970) recherche pour un de ses clients un « Poseur d'enseignes lumineuses » H/F",
+            "Au sein d'une entreprise spécialisée dans la réalisation et la pose d'enseignes lumineuses, vous aurez pour mission:",
+            "- Pose d'enseignes ou d'adhésifs sur façade de bâtiment et magasin.",
+            "- Travail en équipe de 2 avec un chef d'équipe",
+            "- Utilisation de petits outillages",
+            "- Poste parfois en hauteur",
+            "- Contact clientèle",
+            "- Respect des règles de sécurité",
+            "Poste à pourvoir dès que possible pour une période de 6 mois renouvelable.",
+            "Vous souhaitez intégrer une agence d'intérim qui est à votre écoute, réactive dès que vous avez besoin d'un document administratif, qui fait tout pour vous trouver le poste de vos rêves ? ",
+            "Vous en avez marre d'être considéré comme un numéro et vous voulez avoir un sentiment d'appartenance ? ",
+            "Alors rejoignez-nous !",
+            "Targett Interim",
+            "s.vaillant@outlook.fr",
+        ]
         self.assertEqual(split_sentences.split_sentences(text), result)
-        self.assertEqual(split_sentences.split_sentences(text,2), result)
-
+        self.assertEqual(split_sentences.split_sentences(text, 2), result)
 
     def test_split_sentences_7(self):
         # Vals à tester
         text = "Communication: accueil, écoute, transmission d'informations aux partenaires responsables, dialogue, sécurisation de l'enfant.\n\nEducation: apprentissage des règles d'hygiène corporelle de vie en collectivité, aide à l'acquisition des fonctions sensorielles et motrices de l'autonomie, aide au développement affectif et individuel.\n\nExécution: soins d'hygiène corporelle, selon le milieu collectif : préparation, distribution et aide à la prise des repas, entretien courant des locaux et des équipements, fabrication d'éléments simples et aménagement des espaces.\n\nOrganisation: des activités en fonction des besoins des enfants et de la collectivité, du poste de travail, gestion des stocks et des matériaux\n\nVous êtes titulaire du diplôme d'état de puériculture. "
-        result = ["Communication: accueil, écoute, transmission d'informations aux partenaires responsables, dialogue, sécurisation de l'enfant.",
-                  "Education: apprentissage des règles d'hygiène corporelle de vie en collectivité, aide à l'acquisition des fonctions sensorielles et motrices de l'autonomie, aide au développement affectif et individuel.",
-                  "Exécution: soins d'hygiène corporelle, selon le milieu collectif : préparation, distribution et aide à la prise des repas, entretien courant des locaux et des équipements, fabrication d'éléments simples et aménagement des espaces.",
-                  'Organisation: des activités en fonction des besoins des enfants et de la collectivité, du poste de travail, gestion des stocks et des matériaux',
-                  "Vous êtes titulaire du diplôme d'état de puériculture."]
+        result = [
+            "Communication: accueil, écoute, transmission d'informations aux partenaires responsables, dialogue, sécurisation de l'enfant.",
+            "Education: apprentissage des règles d'hygiène corporelle de vie en collectivité, aide à l'acquisition des fonctions sensorielles et motrices de l'autonomie, aide au développement affectif et individuel.",
+            "Exécution: soins d'hygiène corporelle, selon le milieu collectif : préparation, distribution et aide à la prise des repas, entretien courant des locaux et des équipements, fabrication d'éléments simples et aménagement des espaces.",
+            "Organisation: des activités en fonction des besoins des enfants et de la collectivité, du poste de travail, gestion des stocks et des matériaux",
+            "Vous êtes titulaire du diplôme d'état de puériculture.",
+        ]
         self.assertEqual(split_sentences.split_sentences(text), result)
-        self.assertEqual(split_sentences.split_sentences(text,2), result)
-
+        self.assertEqual(split_sentences.split_sentences(text, 2), result)
 
     def test_split_sentences_8(self):
         # Vals à tester
         text = "POSTE  URGENT\nPoste (pour la durée de la crise) en remplacement (pour la durée de la crise) sanitaire.\nmissions recentrées prioritairement autour de l'entretien des locaux (avec renforcement des procédures d'hygiène en lien avec la situation sanitaire! , service des repas, vaisselle... ).\n"
-        result = ['POSTE  URGENT',
-                  'Poste (pour la durée de la crise) en remplacement (pour la durée de la crise) sanitaire.',
-                  "missions recentrées prioritairement autour de l'entretien des locaux (avec renforcement des procédures d'hygiène en lien avec la situation sanitaire! , service des repas, vaisselle... )."]
+        result = [
+            "POSTE  URGENT",
+            "Poste (pour la durée de la crise) en remplacement (pour la durée de la crise) sanitaire.",
+            "missions recentrées prioritairement autour de l'entretien des locaux (avec renforcement des procédures d'hygiène en lien avec la situation sanitaire! , service des repas, vaisselle... ).",
+        ]
         self.assertEqual(split_sentences.split_sentences(text), result)
-        self.assertEqual(split_sentences.split_sentences(text,2), result)
-
+        self.assertEqual(split_sentences.split_sentences(text, 2), result)
 
     def test_split_sentences_9(self):
         # Vals à tester
         text = "* Poste réservé aux personnes titulaires d'une Reconnaissance en Qualité Travailleur Handicapé (RQTH) en cours de validité délivrée par la MDPH\n***\nAu sein d'une usine de fabrication de maroquinerie en cuir vous réalisez : \n- de la coupe et emboutissage de pièces\n- de la mise en épaisseur des matières\n- du thermocollage, encollage\n- de la teinte sur certaines zones du produit\n- de la préparation de lots de pièces complets avant l'assemblage définitif\n\nProfil recherché : Vous avez idéalement un diplôme en couture/maroquinerie ou une expérience industrielle dans le secteur de la maroquinerie. Vous faites preuve de rigueur, de minutie et de dextérité. \nPassionné(e) par le cuir et s'inscrivant dans une démarche Qualité et d'Amélioration Continue permanente et individuelle, vous souhaitez participer à un véritable projet d'entreprise.\nHoraires : de 15h00 à 23h00 du Lundi au Jeudi et de 11h00 à 17h00 le Vendredi.\n"
-        result = ["* Poste réservé aux personnes titulaires d'une Reconnaissance en Qualité Travailleur Handicapé (RQTH) en cours de validité délivrée par la MDPH",
-                  '***',
-                  "Au sein d'une usine de fabrication de maroquinerie en cuir vous réalisez :",
-                  '- de la coupe et emboutissage de pièces',
-                  '- de la mise en épaisseur des matières',
-                  '- du thermocollage, encollage',
-                  '- de la teinte sur certaines zones du produit',
-                  "- de la préparation de lots de pièces complets avant l'assemblage définitif",
-                  'Profil recherché : Vous avez idéalement un diplôme en couture/maroquinerie ou une expérience industrielle dans le secteur de la maroquinerie. ',
-                  'Vous faites preuve de rigueur, de minutie et de dextérité.',
-                  "Passionné(e) par le cuir et s'inscrivant dans une démarche Qualité et d'Amélioration Continue permanente et individuelle, vous souhaitez participer à un véritable projet d'entreprise.",
-                  'Horaires : de 15h00 à 23h00 du Lundi au Jeudi et de 11h00 à 17h00 le Vendredi.']
+        result = [
+            "* Poste réservé aux personnes titulaires d'une Reconnaissance en Qualité Travailleur Handicapé (RQTH) en cours de validité délivrée par la MDPH",
+            "***",
+            "Au sein d'une usine de fabrication de maroquinerie en cuir vous réalisez :",
+            "- de la coupe et emboutissage de pièces",
+            "- de la mise en épaisseur des matières",
+            "- du thermocollage, encollage",
+            "- de la teinte sur certaines zones du produit",
+            "- de la préparation de lots de pièces complets avant l'assemblage définitif",
+            "Profil recherché : Vous avez idéalement un diplôme en couture/maroquinerie ou une expérience industrielle dans le secteur de la maroquinerie. ",
+            "Vous faites preuve de rigueur, de minutie et de dextérité.",
+            "Passionné(e) par le cuir et s'inscrivant dans une démarche Qualité et d'Amélioration Continue permanente et individuelle, vous souhaitez participer à un véritable projet d'entreprise.",
+            "Horaires : de 15h00 à 23h00 du Lundi au Jeudi et de 11h00 à 17h00 le Vendredi.",
+        ]
         self.assertEqual(split_sentences.split_sentences(text), result)
-        self.assertEqual(split_sentences.split_sentences(text,2), result)
-
+        self.assertEqual(split_sentences.split_sentences(text, 2), result)
 
     def test_split_sentences_10(self):
         # Vals à tester
         text = "-  Proposer une solution efficace aux demandes de vos clients, dans le respect des procédures (informations, administratif, suivi contractuel, facturation\n-  Traiter leurs réclamation\n-  Garantir la satisfaction et la fidélisation des clients au quotidien\nNotre client vous garantit :\n-  Une entreprise à l'écoute, où tout le monde a son rôle à jouer et peut proposer ses idées.\n-  Une proximité avec les managers dans une démarche d'amélioration continue, avec une vraie culture de bonnes pratiques et de partage.\n-  Des positions de travail étudiées pour vous assurer le meilleur confort\nPoste à temps complet, 35h/semaine\nAmplitude horaires : du lundi au vendredi de 8h30 à 19h et le samedi de 8h30 à 18h\nAccessible en Transports en Communs \nVotre profil :\n- Vous avez le sourire,\n-  Vous êtes ponctuel,\n-  Vous avez l'envie et la volonté,\n-  Vos capacités d'écoute et votre sens du service sont des atouts que l'on vous reconnaît,\n-  Vous êtes rigoureux et organisé,\n-  Vous êtes à l'aise avec la gestion des oup informatiques,\n-  Vous vous exprimez parfaitement à l'écrit comme à l'oral\n-  Vous êtes disponible et motivé\nExpérience:\n- conseiller client h/f ou similaire: 1 an, débutant ayant affinité avec la relation client accepté\nAccompagné tout au long de votre parcours d'intégration, vous maitriserez rapidement la relation client et les différents produits. Le suivi personnalisé par une équipe de formateurs confirmés permettra d'optimiser votre montée en compétence.\nLe savoir être est un élément essentiel du recrutement pour ce poste \nRémunération et avantages :\n-  Taux horaire fixe + 10% de fin de mission + 10% de congés payés\n-  Primes collective et/ou individuelle + participation aux bénéfices + CET 5%\n-  Acompte de paye à la semaine si besoin,\n-  Possibilité d'intégration rapide, de formation et d'évolution,\n-  Bénéficiez d'aides et de services dédiés (mutuelle, logement, garde enfant, déplacement )."
-        result = ['-  Proposer une solution efficace aux demandes de vos clients, dans le respect des procédures (informations, administratif, suivi contractuel, facturation',
-                  '-  Traiter leurs réclamation',
-                  '-  Garantir la satisfaction et la fidélisation des clients au quotidien',
-                  'Notre client vous garantit :',
-                  "-  Une entreprise à l'écoute, où tout le monde a son rôle à jouer et peut proposer ses idées.",
-                  "-  Une proximité avec les managers dans une démarche d'amélioration continue, avec une vraie culture de bonnes pratiques et de partage.",
-                  '-  Des positions de travail étudiées pour vous assurer le meilleur confort',
-                  'Poste à temps complet, 35h/semaine',
-                  'Amplitude horaires : du lundi au vendredi de 8h30 à 19h et le samedi de 8h30 à 18h',
-                  'Accessible en Transports en Communs',
-                  'Votre profil :',
-                  '- Vous avez le sourire,',
-                  '-  Vous êtes ponctuel,',
-                  "-  Vous avez l'envie et la volonté,",
-                  "-  Vos capacités d'écoute et votre sens du service sont des atouts que l'on vous reconnaît,",
-                  '-  Vous êtes rigoureux et organisé,',
-                  "-  Vous êtes à l'aise avec la gestion des oup informatiques,",
-                  "-  Vous vous exprimez parfaitement à l'écrit comme à l'oral",
-                  '-  Vous êtes disponible et motivé',
-                  'Expérience:',
-                  '- conseiller client h/f ou similaire: 1 an, débutant ayant affinité avec la relation client accepté',
-                  "Accompagné tout au long de votre parcours d'intégration, vous maitriserez rapidement la relation client et les différents produits. ",
-                  "Le suivi personnalisé par une équipe de formateurs confirmés permettra d'optimiser votre montée en compétence.",
-                  'Le savoir être est un élément essentiel du recrutement pour ce poste',
-                  'Rémunération et avantages :',
-                  '-  Taux horaire fixe + 10% de fin de mission + 10% de congés payés',
-                  '-  Primes collective et/ou individuelle + participation aux bénéfices + CET 5%',
-                  '-  Acompte de paye à la semaine si besoin,',
-                  "-  Possibilité d'intégration rapide, de formation et d'évolution,",
-                  "-  Bénéficiez d'aides et de services dédiés (mutuelle, logement, garde enfant, déplacement )."]
+        result = [
+            "-  Proposer une solution efficace aux demandes de vos clients, dans le respect des procédures (informations, administratif, suivi contractuel, facturation",
+            "-  Traiter leurs réclamation",
+            "-  Garantir la satisfaction et la fidélisation des clients au quotidien",
+            "Notre client vous garantit :",
+            "-  Une entreprise à l'écoute, où tout le monde a son rôle à jouer et peut proposer ses idées.",
+            "-  Une proximité avec les managers dans une démarche d'amélioration continue, avec une vraie culture de bonnes pratiques et de partage.",
+            "-  Des positions de travail étudiées pour vous assurer le meilleur confort",
+            "Poste à temps complet, 35h/semaine",
+            "Amplitude horaires : du lundi au vendredi de 8h30 à 19h et le samedi de 8h30 à 18h",
+            "Accessible en Transports en Communs",
+            "Votre profil :",
+            "- Vous avez le sourire,",
+            "-  Vous êtes ponctuel,",
+            "-  Vous avez l'envie et la volonté,",
+            "-  Vos capacités d'écoute et votre sens du service sont des atouts que l'on vous reconnaît,",
+            "-  Vous êtes rigoureux et organisé,",
+            "-  Vous êtes à l'aise avec la gestion des oup informatiques,",
+            "-  Vous vous exprimez parfaitement à l'écrit comme à l'oral",
+            "-  Vous êtes disponible et motivé",
+            "Expérience:",
+            "- conseiller client h/f ou similaire: 1 an, débutant ayant affinité avec la relation client accepté",
+            "Accompagné tout au long de votre parcours d'intégration, vous maitriserez rapidement la relation client et les différents produits. ",
+            "Le suivi personnalisé par une équipe de formateurs confirmés permettra d'optimiser votre montée en compétence.",
+            "Le savoir être est un élément essentiel du recrutement pour ce poste",
+            "Rémunération et avantages :",
+            "-  Taux horaire fixe + 10% de fin de mission + 10% de congés payés",
+            "-  Primes collective et/ou individuelle + participation aux bénéfices + CET 5%",
+            "-  Acompte de paye à la semaine si besoin,",
+            "-  Possibilité d'intégration rapide, de formation et d'évolution,",
+            "-  Bénéficiez d'aides et de services dédiés (mutuelle, logement, garde enfant, déplacement ).",
+        ]
         self.assertEqual(split_sentences.split_sentences(text), result)
-        self.assertEqual(split_sentences.split_sentences(text,2), result)
+        self.assertEqual(split_sentences.split_sentences(text, 2), result)
 
     def test_split_acronyms(self):
         text = "Au sein d'une usine de fabrication de A. T. R. S.\nM. Machin sera votre superviseur"
-        result = ["Au sein d'une usine de fabrication de A. ","T. ","R. ","S.","M. ","Machin sera votre superviseur"]
-        self.assertEqual(split_sentences.split_sentences(text), result) # too many splits
-        result = ["Au sein d'une usine de fabrication de A. T. R. S.","M. Machin sera votre superviseur"]
-        self.assertEqual(split_sentences.split_sentences(text,2), result)
+        result = [
+            "Au sein d'une usine de fabrication de A. ",
+            "T. ",
+            "R. ",
+            "S.",
+            "M. ",
+            "Machin sera votre superviseur",
+        ]
+        self.assertEqual(
+            split_sentences.split_sentences(text), result
+        )  # too many splits
+        result = [
+            "Au sein d'une usine de fabrication de A. T. R. S.",
+            "M. Machin sera votre superviseur",
+        ]
+        self.assertEqual(split_sentences.split_sentences(text, 2), result)
 
     def test_split_extra_parenthesis(self):
         text = " Je suis bon en langues (Anglais (Lu, Parlé). Espagnol (Parlé)) et en sports"
-        result= [" Je suis bon en langues (Anglais (Lu, Parlé). ","Espagnol (Parlé)) et en sports"]
-        self.assertEqual(split_sentences.split_sentences(text), [text]) # error in parenthesis split
-        result= [" Je suis bon en langues (Anglais (Lu, Parlé). Espagnol (Parlé)) et en sports"]
-        self.assertEqual(split_sentences.split_sentences(text,2), result) # v2 = no split, '.' in parenthesis
-
+        result = [
+            " Je suis bon en langues (Anglais (Lu, Parlé). ",
+            "Espagnol (Parlé)) et en sports",
+        ]
+        self.assertEqual(
+            split_sentences.split_sentences(text), [text]
+        )  # error in parenthesis split
+        result = [
+            " Je suis bon en langues (Anglais (Lu, Parlé). Espagnol (Parlé)) et en sports"
+        ]
+        self.assertEqual(
+            split_sentences.split_sentences(text, 2), result
+        )  # v2 = no split, '.' in parenthesis
 
     def test_split_sentences_df(self):
-        '''Fonction pour vérifier le fonctionnement de la fonction split_sentences_df'''
+        """Fonction pour vérifier le fonctionnement de la fonction split_sentences_df"""
 
         # Get df to test & result
-        df = pd.DataFrame({
-            'OFF_CLE' : ['c1', 'c2'],
-            'OFF_DESCRIPTION' : ['t1\nt2', 't3\nt4. t5'],
-        })
+        df = pd.DataFrame(
+            {
+                "OFF_CLE": ["c1", "c2"],
+                "OFF_DESCRIPTION": ["t1\nt2", "t3\nt4. t5"],
+            }
+        )
         df2 = df.copy()
-        df_result = pd.DataFrame({
-            'OFF_CLE' : ['c1', 'c1', 'c2', 'c2', 'c2'],
-            'OFF_DESCRIPTION' : ['t1', 't2', 't3', 't4. ', 't5'],
-        })  # Offres PE en premier
+        df_result = pd.DataFrame(
+            {
+                "OFF_CLE": ["c1", "c1", "c2", "c2", "c2"],
+                "OFF_DESCRIPTION": ["t1", "t2", "t3", "t4. ", "t5"],
+            }
+        )  # Offres PE en premier
 
         # split_sentences_df(df, col)
-        df_processed = split_sentences.split_sentences_df(df, 'OFF_DESCRIPTION')
+        df_processed = split_sentences.split_sentences_df(df, "OFF_DESCRIPTION")
         pd.testing.assert_frame_equal(df_processed, df_result)
-        df_processed = split_sentences.split_sentences_df(df, 'OFF_DESCRIPTION', version=2)
+        df_processed = split_sentences.split_sentences_df(
+            df, "OFF_DESCRIPTION", version=2
+        )
         pd.testing.assert_frame_equal(df_processed, df_result)
-        pd.testing.assert_frame_equal(df, df2)  # On check si pas de modif. sur df original
-
+        pd.testing.assert_frame_equal(
+            df, df2
+        )  # On check si pas de modif. sur df original
 
 
 # Execution des tests
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Start tests
     unittest.main()

--- a/words_n_fun/preprocessing/split_sentences.py
+++ b/words_n_fun/preprocessing/split_sentences.py
@@ -43,27 +43,29 @@ re_lastspace = re.compile(r"\s+$")
 # Detect parenthesis
 re_parenthesis = re.compile(r"\([^())]+\)")
 # Regex to split punctuation ignoring classicar acronims
-re_specialsplit_v1 = re.compile("(?<!\s\w\.\w.\s)(?<!\sM\.\s)(?<=(?:\.|\?|\!)\s)")
-re_specialsplit_v2 = re.compile(r"(?<!^\w.\s)(?<!\s\w.\s)(?<!\w\.\w.\s)(?<!\bMme\.\s)(?<!\bDr\.\s)(?<=(?:\.|\?|\!)\s)")
+re_specialsplit_v1 = re.compile("(?<!\s\w\.\w\.\s)(?<!\sM\.\s)(?<=(?:\.|\?|\!)\s)")
+re_specialsplit_v2 = re.compile(
+    r"(?<!^\w.\s)(?<!\s\w.\s)(?<!\w\.\w\.\s)(?<!\bMme\.\s)(?<!\bDr\.\s)(?<=(?:\.|\?|\!)\s)"
+)
 
 
 def parenthesis_to_key(line: str) -> Tuple[str, List[Tuple]]:
-    """ Replace parenthesis content for UID_PE_PARENTHESES_{k}
-        We do iteratively to avoid problems with imbricated parenthesis
+    """Replace parenthesis content for UID_PE_PARENTHESES_{k}
+    We do iteratively to avoid problems with imbricated parenthesis
     """
     k = 0
     matches = []
     while match := re_parenthesis.search(line):
         parenthesis = match.group()
         replacement = f"UID_PE_PARENTHESES_{k}"
-        matches.append((replacement,parenthesis))
+        matches.append((replacement, parenthesis))
         line = line.replace(parenthesis, replacement, 1)
         k += 1
-    return line, matches    
+    return line, matches
+
 
 def key_to_parenthesis(lines: List[str], key_parenthesis: List[Tuple]) -> List[str]:
-    """ apply parenthesis to a group of lines
-    """
+    """apply parenthesis to a group of lines"""
     # verify there are parenthesis to replace
     if not key_parenthesis:
         return lines
@@ -72,40 +74,40 @@ def key_to_parenthesis(lines: List[str], key_parenthesis: List[Tuple]) -> List[s
         # do replacement iteratively
         while "UID_PE_PARENTHESES" in line:
             # reversed because the last one should be replaced first
-            for key,value in reversed(key_parenthesis):
-                line = line.replace(key, value,1)
+            for key, value in reversed(key_parenthesis):
+                line = line.replace(key, value, 1)
         lines[i] = line
     return lines
 
 
-def split_sentences(text: str, version:int=1) -> List[str]:
-    ''' Splits a text into sentences
+def split_sentences(text: str, version: int = 1) -> List[str]:
+    """Splits a text into sentences
         - Parenthesis are removed before split so parenthesis are not splitted
         - Split by \n and then punctuation: '. ', '? ','! '
-        - Classic acronyms are avoided M., Mme.,Dr,  A.C.M.E or A. C. M. E. 
+        - Classic acronyms are avoided M., Mme.,Dr,  A.C.M.E or A. C. M. E.
 
     Args:
         text (str): Arbitrary text
         version (int): 1 = original version, 2 = extra rules are added
     Returns:
         list<str> : List of sentences
-    '''
-    assert version in [1,2], " Vsplit_sentences version must be 1 or 2"
+    """
+    if version not in [1, 2]:
+        raise ValueError(" split_sentences version must be 1 or 2")
     re_specialsplit = re_specialsplit_v2 if version == 2 else re_specialsplit_v1
     # We split around \n after singling them out and removing trailing spaces.
-    text = re_multiline.sub('\n', text)
-    text = re_lastspace.sub('', text)
-    text_lines = text.split('\n')
-
+    text = re_multiline.sub("\n", text)
+    text = re_lastspace.sub("", text)
+    text_lines = text.split("\n")
 
     text_list = []
 
     for i, sentence in enumerate(text_lines):
         # replace parenthesis
-        sentence, key_paren = parenthesis_to_key( sentence)
-        
+        sentence, key_paren = parenthesis_to_key(sentence)
+
         # split sentences
-         # We split around ".", "!", "?" if they are followed by a whitespace or a newline
+        # We split around ".", "!", "?" if they are followed by a whitespace or a newline
         # Special occurences ("i.e", "e.g", "M.") are skipped
         splits = re_specialsplit.split(sentence)
 
@@ -118,24 +120,28 @@ def split_sentences(text: str, version:int=1) -> List[str]:
     return text_list
 
 
-def split_sentences_df(df: pd.DataFrame, col: Union[str, int], use_tqdm: bool = False, version:int=1) -> pd.DataFrame:
-    '''Function to split several texts from a pandas DataFrame into sentences
+def split_sentences_df(
+    df: pd.DataFrame, col: Union[str, int], use_tqdm: bool = False, version: int = 1
+) -> pd.DataFrame:
+    """Function to split several texts from a pandas DataFrame into sentences
 
     Args:
         df (pd.DataFrame): DataFrame containing the texts
         col (str ou int): Column name where the text is
     Returns:
         pd.DataFrame: New DataFrame with the text split into sentences
-    '''
+    """
     func = functools.partial(split_sentences, version=version)
     df2 = df.copy()
     if use_tqdm:
         df2[col] = df2[col].progress_apply(func)
     else:
         df2[col] = df2[col].apply(func)
-        
+
     return df2.explode(col).reset_index(drop=True)
 
 
-if __name__ == '__main__':
-    logger.error("This script is not stand alone but belongs to a package that has to be imported.")
+if __name__ == "__main__":
+    logger.error(
+        "This script is not stand alone but belongs to a package that has to be imported."
+    )

--- a/words_n_fun/preprocessing/split_sentences.py
+++ b/words_n_fun/preprocessing/split_sentences.py
@@ -24,9 +24,9 @@
 
 import re
 import logging
+import functools
 import pandas as pd
-from itertools import chain
-from typing import Union, List
+from typing import Union, List, Tuple
 
 from words_n_fun import CustomTqdm as tqdm
 
@@ -35,49 +35,90 @@ tqdm.pandas()
 # Get logger
 logger = logging.getLogger(__name__)
 
+# REGEX USED
+# Join several \n
+re_multiline = re.compile(r"\s*\n+")
+# Remove last spaces
+re_lastspace = re.compile(r"\s+$")
+# Detect parenthesis
+re_parenthesis = re.compile(r"\([^())]+\)")
+# Regex to split punctuation ignoring classicar acronims
+re_specialsplit_v1 = re.compile("(?<!\s\w\.\w.\s)(?<!\sM\.\s)(?<=(?:\.|\?|\!)\s)")
+re_specialsplit_v2 = re.compile(r"(?<!^\w.\s)(?<!\s\w.\s)(?<!\w\.\w.\s)(?<!\bMme\.\s)(?<!\bDr\.\s)(?<=(?:\.|\?|\!)\s)")
 
-def split_sentences(text: str) -> List[str]:
-    '''Splits a text into sentences
+
+def parenthesis_to_key(line: str) -> Tuple[str, List[Tuple]]:
+    """ Replace parenthesis content for UID_PE_PARENTHESES_{k}
+        We do iteratively to avoid problems with imbricated parenthesis
+    """
+    k = 0
+    matches = []
+    while match := re_parenthesis.search(line):
+        parenthesis = match.group()
+        replacement = f"UID_PE_PARENTHESES_{k}"
+        matches.append((replacement,parenthesis))
+        line = line.replace(parenthesis, replacement, 1)
+        k += 1
+    return line, matches    
+
+def key_to_parenthesis(lines: List[str], key_parenthesis: List[Tuple]) -> List[str]:
+    """ apply parenthesis to a group of lines
+    """
+    # verify there are parenthesis to replace
+    if not key_parenthesis:
+        return lines
+
+    for i, line in enumerate(lines):
+        # do replacement iteratively
+        while "UID_PE_PARENTHESES" in line:
+            # reversed because the last one should be replaced first
+            for key,value in reversed(key_parenthesis):
+                line = line.replace(key, value,1)
+        lines[i] = line
+    return lines
+
+
+def split_sentences(text: str, version:int=1) -> List[str]:
+    ''' Splits a text into sentences
+        - Parenthesis are removed before split so parenthesis are not splitted
+        - Split by \n and then punctuation: '. ', '? ','! '
+        - Classic acronyms are avoided M., Mme.,Dr,  A.C.M.E or A. C. M. E. 
 
     Args:
         text (str): Arbitrary text
+        version (int): 1 = original version, 2 = extra rules are added
     Returns:
         list<str> : List of sentences
     '''
-
+    assert version in [1,2], " Vsplit_sentences version must be 1 or 2"
+    re_specialsplit = re_specialsplit_v2 if version == 2 else re_specialsplit_v1
     # We split around \n after singling them out and removing trailing spaces.
-    text = re.compile("\s*\n+").sub('\n', text)
-    text = re.compile("\s+$").sub('', text)
-    text_list = text.split('\n')
+    text = re_multiline.sub('\n', text)
+    text = re_lastspace.sub('', text)
+    text_lines = text.split('\n')
 
-    # Text between parenthesis are kept aside
-    parentheses_matches = {}
-    parentheses_regex = r"\(([^)]+)\)"
-    k = 0  # Incrementation UID
-    for i, sentence in enumerate(text_list):
-        for match in re.compile(parentheses_regex).finditer(sentence):
-            tmp_text = match.group()
-            tmp_replace = f"UID_PE_PARENTHESES_{k}"
-            parentheses_matches[tmp_replace] = tmp_text
-            sentence = sentence.replace(tmp_text, tmp_replace, 1)
-            text_list[i] = sentence
-            k += 1
 
-    # We split around ".", "!", "?" if they are followed by a whitespace or a newline
-    # Special occurences ("i.e", "e.g", "M.") are skipped
-    regex = "(?<!\s\w\.\w.\s)(?<!\sM\.\s)(?<=(?:\.|\?|\!)\s)"
-    text_list = list(chain.from_iterable([re.compile(regex).split(_) for _ in text_list]))
+    text_list = []
 
-    # Parenthesis texts are injected back in the list
-    for i, elem in enumerate(text_list):
-        for k in parentheses_matches.keys():
-            elem = elem.replace(k, parentheses_matches[k])
-        text_list[i] = elem
+    for i, sentence in enumerate(text_lines):
+        # replace parenthesis
+        sentence, key_paren = parenthesis_to_key( sentence)
+        
+        # split sentences
+         # We split around ".", "!", "?" if they are followed by a whitespace or a newline
+        # Special occurences ("i.e", "e.g", "M.") are skipped
+        splits = re_specialsplit.split(sentence)
+
+        # reapply parenthesis
+        sentences = key_to_parenthesis(splits, key_paren)
+
+        # combine all sentences
+        text_list.extend(sentences)
 
     return text_list
 
 
-def split_sentences_df(df: pd.DataFrame, col: Union[str, int], use_tqdm: bool = False) -> pd.DataFrame:
+def split_sentences_df(df: pd.DataFrame, col: Union[str, int], use_tqdm: bool = False, version:int=1) -> pd.DataFrame:
     '''Function to split several texts from a pandas DataFrame into sentences
 
     Args:
@@ -86,11 +127,12 @@ def split_sentences_df(df: pd.DataFrame, col: Union[str, int], use_tqdm: bool = 
     Returns:
         pd.DataFrame: New DataFrame with the text split into sentences
     '''
+    func = functools.partial(split_sentences, version=version)
     df2 = df.copy()
     if use_tqdm:
-        df2[col] = df2[col].progress_apply(split_sentences)
+        df2[col] = df2[col].progress_apply(func)
     else:
-        df2[col] = df2[col].apply(split_sentences)
+        df2[col] = df2[col].apply(func)
         
     return df2.explode(col).reset_index(drop=True)
 


### PR DESCRIPTION
<!--
Before contributing :

⚠️ Any contribution that is more than a few lines of code must be stated on the corresponding issue. If there is no issue for it yet, please create it first.

This ensure that :

  1. Two people aren't working on the same thing
	2. This is something Words'n Fun's maintainers believe should be implemented/fixed
  3. Your time is well spent :)

-->

## ✒️ Context

Method split_sentences had a bug with parenthesis and some regexes could be improved. 

- What kind of change does this PR introduce ?

  - [x] Bugfix
  - [x] Feature
  - [x] Refactoring
  - [ ] Other, please describe:

## 🧱 Description of Changes

- Refactor code about extracting parenthesis, and regexes
- Fix bug with perenthesis
- Improve regex with special cases (acronyms, M. Mme. ...)
- Increase tests with more specific test cases
- To maintain compatibility a parameter version was added (default is previous version)


## 🩺 Testing

- _Add bullet points summarizing your changes here_

  - [ ] This change does not need new tests
  - [x] Added/Updated unit tests

## 🔗 References

_Does this depend on other work, documents, or tickets?_

- **Issue**: Closes #XXXX

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the GNU AFFERO GENERAL PUBLIC LICENSE.
